### PR TITLE
fix strategyMove with plain arrays

### DIFF
--- a/src/knockout-sortable.js
+++ b/src/knockout-sortable.js
@@ -290,7 +290,7 @@
                                             var underlyingList = unwrap(sourceParent);
 
                                             // notify 'beforeChange' subscribers
-                                            sourceParent.valueWillMutate();
+                                            sourceParent.valueWillMutate && sourceParent.valueWillMutate();
 
                                             // move from source index ...
                                             underlyingList.splice(sourceIndex, 1);
@@ -298,7 +298,7 @@
                                             underlyingList.splice(targetIndex, 0, item);
 
                                             // notify subscribers
-                                            sourceParent.valueHasMutated();
+                                            sourceParent.valueHasMutated && sourceParent.valueHasMutated();
                                         }
                                     }
                                     else {


### PR DESCRIPTION
If using a plain array as data source, for example when using knockout-es5, the "valueWillMutate" and "valueHasMutated" methods do not exist and do not need to be called, if they don't.
